### PR TITLE
Fetch dragons data

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import planet from '../image/planet.png';
+import '../styles/index.css';
 
 const Navbar = () => {
   const links = [

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,13 +1,6 @@
-/* stylelint-disable */
-/* eslint-disable */
-
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import planet from '../image/planet.png';
-import Missions from './Missions';
-import Profiles from './Profiles';
-import Rockets from './Rockets';
-import Dragons from './Dragons';
 
 const Navbar = () => {
   const links = [
@@ -41,7 +34,7 @@ const Navbar = () => {
     <nav className="navbar">
       <header className="logo-container">
         <img src={planet} alt="Logo" className="logo" />
-        <h1 className="title"> Space Travelers & rsquo; Hub </h1>
+        <h1 className="title"> Space Travelers&rsquo; Hub </h1>
       </header>
       {' '}
       <ul className="links">
@@ -65,16 +58,6 @@ const Navbar = () => {
         </NavLink>
       </div>
       {' '}
-      <Switch>
-        <Route exact path="/" component={Rockets} />
-        {' '}
-        <Route path="/missions" component={Missions} />
-        {' '}
-        <Route path="/profiles" component={Profiles} />
-        {' '}
-        <Route path="/dragons" component={Dragons} />
-        {' '}
-      </Switch>
     </nav>
   );
 };

--- a/src/pages/Dragons.js
+++ b/src/pages/Dragons.js
@@ -1,16 +1,12 @@
-/* stylelint-disable */
-/* eslint-disable */
-
 import { useSelector, useDispatch } from 'react-redux';
 import React, { useEffect } from 'react';
-import {
-  // reserveDragons,
-  fetchData,
-  // cancelReservation,
-} from '../store/reducers/actions/dragonActions.js';
+import {} from '../store/reducers/dragonReducer';
+
+import { fetchData } from '../store/reducers/actions/dragonActions';
 
 const Dragons = () => {
-  const dragonStore = useSelector((state) => state.dragons);
+  const dragonStore = useSelector((state) => state.dragons.dragons);
+  console.log(dragonStore);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -4,9 +4,11 @@ import thunk from 'redux-thunk';
 import logger from 'redux-logger';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import rocketsReducer from './reducers/rootReducer';
+import dragonReducer from './reducers/dragonReducer';
 
 const reducers = combineReducers({
   rockets: rocketsReducer,
+  dragons: dragonReducer,
 });
 
 const middlwares = [thunk, logger];

--- a/src/store/reducers/actions/actions.js
+++ b/src/store/reducers/actions/actions.js
@@ -1,9 +1,6 @@
-/* stylelint-disable */
-/* eslint-disable */
-
 /* eslint-disable import/prefer-default-export */
 import axios from 'axios';
-import { GET_ROCKETS, SET_ROCKETS, ERROR_ROCKETS } from './types';
+import { GET_ROCKETS, SET_ROCKETS, ERROR_ROCKETS } from '../../types';
 
 export const getRocketsAction = () => async (dispatch) => {
   const baseUrl = 'https://api.spacexdata.com/v3/rockets';

--- a/src/store/reducers/actions/dragonActions.js
+++ b/src/store/reducers/actions/dragonActions.js
@@ -1,5 +1,10 @@
-/* stylelint-disable */
-/* eslint-disable */
+import {
+  url,
+  LOAD_DRAGONS,
+  RESERVE_DRAGONS,
+  CANCEL_RESERVATION,
+  LOAD_FAILED,
+} from '../../types';
 
 const loadDragons = (dragons) => ({
   type: LOAD_DRAGONS,
@@ -25,7 +30,6 @@ export const fetchData = () => async (dispatch) => {
   try {
     const response = await fetch(url);
     const dragons = await response.json();
-    console.log(dragons);
 
     dispatch(
       loadDragons(

--- a/src/store/reducers/dragonReducer.js
+++ b/src/store/reducers/dragonReducer.js
@@ -1,5 +1,4 @@
-/* stylelint-disable */
-/* eslint-disable */
+import { LOAD_DRAGONS, LOAD_FAILED, initialState } from '../types';
 
 const dragonReducer = (state = initialState, action) => {
   switch (action.type) {

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -1,16 +1,13 @@
-/* stylelint-disable */
-/* eslint-disable */
-
 export const GET_ROCKETS = 'space-travelers-hub/rockets/GET_ROCKETS';
 export const SET_ROCKETS = 'space-travelers-hub/rockets/SET_ROCKETS';
 export const ERROR_ROCKETS = 'space-travelers-hub/rockets/ERROR_ROCKETS';
 
-const LOAD_DRAGONS = 'LOAD_DRAGONS';
-const RESERVE_DRAGONS = 'RESERVE_DRAGONS';
-const CANCEL_RESERVATION = 'CANCEL_RESERVATION';
-const LOAD_FAILED = 'LOAD_FAILED';
-const url = 'https://api.spacexdata.com/v3/dragons';
+export const LOAD_DRAGONS = 'LOAD_DRAGONS';
+export const RESERVE_DRAGONS = 'RESERVE_DRAGONS';
+export const CANCEL_RESERVATION = 'CANCEL_RESERVATION';
+export const LOAD_FAILED = 'LOAD_FAILED';
+export const url = 'https://api.spacexdata.com/v3/dragons';
 
-const initialState = {
+export const initialState = {
   dragons: [],
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,6 @@
-/* @tailwind base;
+/* stylelint-disable */
+/* eslint-disable */
+
+@tailwind base;
 @tailwind components;
-@tailwind utilities; */
+@tailwind utilities;


### PR DESCRIPTION
## In this pull request, I did the following:
- Fetch data (id, name, type, flickr_images) from the Dragons endpoint (https://api.spacexdata.com/v3/dragons) when a user navigates to the Dragons section.
- Dispatch an action to store the selected data in Redux store once data is fetched
- Restructure and organize file structure for dragon component, actions, and reducer